### PR TITLE
Dub/some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cluster: "mainnet"
 location: "ny"
 
 # Commission is in basis points (bps). 100 bps = 1%
-commission-bps: 800
+commission_bps: 800
 # Optional. This sends metricss to Solana's public influx and it is encouraged to set to true since it helps Solana Labs and others debug your validator as well as network issues.
 metrics: true
 org_name: "jito-foundation"

--- a/roles/common/tasks/swap.yaml
+++ b/roles/common/tasks/swap.yaml
@@ -29,7 +29,8 @@
 - name: Write swap entry in fstab
   become: true
   become_user: root
-  mount: name=none
+  mount:
+    name=none
     src=/mnt/swapfile
     fstype=swap
     opts=sw

--- a/roles/jito/defaults/main.yaml
+++ b/roles/jito/defaults/main.yaml
@@ -9,7 +9,7 @@ cluster: mainnet
 location: "ny"
 
 # commission in basis points. 100 bps = 1%
-commission-bps: 800
+commission_bps: 800
 
 rpc_address: https://api.mainnet-beta.solana.com
 

--- a/roles/jito/tasks/build.yaml
+++ b/roles/jito/tasks/build.yaml
@@ -1,7 +1,7 @@
 - name: build solana
   become: true
-  become_user: root
-  shell: "cd /mnt/{{ repo_dir }} && ./cargo stable build --release"
+  become_user: solana
+  shell: "source /home/solana/.cargo/env && cd /mnt/{{ repo_dir }} && ./cargo stable build --release"
   args:
     chdir: "/mnt/{{ repo_dir }}"
     executable: /bin/bash

--- a/roles/jito/templates/validator.sh.j2
+++ b/roles/jito/templates/validator.sh.j2
@@ -20,7 +20,7 @@
       --tip-payment-program-pubkey T1pyyaTNZsKv2WcRAB8oVnk93mLJw2XzjtVYqCsaHqt \
       --tip-distribution-program-pubkey 4R3gSG8BpU4t19KYj8CfnbtRpnT8gtk4dvTHxVRwc2r7 \
       --merkle-root-upload-authority GZctHpWXmsZC1YHACTGGcHhYxjdRqQvTpYkb9LMvxDib \
-      --commission-bps {{ commission-bps }} \
+      --commission-bps {{ commission_bps }} \
       --relayer-url {{ jito_relayer_url }} \
       --block-engine-url {{ jito_block_engine_url }} \
       --expected-bank-hash 69p75jzzT1P2vJwVn3wbTVutxHDcWKAgcbjqXvwCVUDE \
@@ -44,7 +44,7 @@
       --tip-payment-program-pubkey DCN82qDxJAQuSqHhv2BJuAgi41SPeKZB5ioBCTMNDrCC \
       --tip-distribution-program-pubkey F2Zu7QZiTYUhPd7u9ukRVwxh7B71oA3NMJcHuCHc29P2 \
       --merkle-root-upload-authority ESgP63knYThVSNWcwgwzA8cnh2MnUf6SaCWpnC8mrkn3 \
-      --commission-bps {{ commission-bps }} \
+      --commission-bps {{ commission_bps }} \
       --relayer-url {{ jito_relayer_url }} \
       --block-engine-url {{ jito_block_engine_url }} \
       --shred-receiver-address {{ jito_shred_receiver_address }}

--- a/setup.yaml
+++ b/setup.yaml
@@ -2,5 +2,5 @@
 - name: "playbook runner"
   hosts: "validators"
   roles:
-    #    - "./roles/common"
+    - "./roles/common"
     - "./roles/jito"

--- a/setup.yaml
+++ b/setup.yaml
@@ -2,5 +2,5 @@
 - name: "playbook runner"
   hosts: "validators"
   roles:
-    - "./roles/common"
+    #    - "./roles/common"
     - "./roles/jito"


### PR DESCRIPTION
* ./cargo in the repo directory still requires cargo installed and in the path (so added source /home/solana/.cargo/env)
* {{ commission-bps }} is being parsed as commission - bps (subtract).. just changed it to commission_bps to avoid the issue (there are other workarounds, but _ is used for other vars as well so just used it for this as well. modified README too